### PR TITLE
Fixes a bug with assigned sections

### DIFF
--- a/script/mct/modules/option_obj.lua
+++ b/script/mct/modules/option_obj.lua
@@ -167,7 +167,7 @@ end
 function mct_option:set_assigned_section(section_key)
     local mod = self:get_mod()
     local section = mod:get_section_by_key(section_key)
-    if mct:is_mct_section(section) then
+    if not mct:is_mct_section(section) then
         mct:log("set_assigned_section() called for option ["..self:get_key().."] in mod ["..mod:get_key().."] but no section with the key ["..section_key.."] was found!")
         return false
         


### PR DESCRIPTION
Today's Steam release has a notty bug that prevents `mct_option:set_assigned_section` from working.