### PR TITLE
Fix script break on load when user enables new mods

### DIFF
--- a/script/mct/modules/settings.lua
+++ b/script/mct/modules/settings.lua
@@ -677,7 +677,7 @@ function settings:load()
             local next = next
 
             -- only clear out this mod from content (from an empty table {} to nil) if it's completely empty from the previous operation
-            if next(content[mod_key]) == nil then
+            if content[mod_key] and next(content[mod_key]) == nil then
                 content[mod_key] = nil
             end
         end


### PR DESCRIPTION
This fixes #139, or at least the cases I know about from that issue. You can test the fix using the steps for reproducing the bug that I included in a comment on that issue.